### PR TITLE
add https clone path option in case of error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ https://guides.github.com/activities/hello-world/
 git clone git@github.com:CitizensForPositiveChange/hackathon.git
 ```
 
+- if the above throws an error try
+
+```
+git clone https://git@github.com/CitizensForPositiveChange/hackathon.git
+```
+
 - You just cloned a copy of the master branch on to your local machine from the 'origin' or from github.  The master branch contains the master copy of all our collaborative code.
 
 - It is good practice to always pull from master before creating a new branch. This will help you avoid merge conficts in the future!


### PR DESCRIPTION
found this solution when error occurred: https://stackoverflow.com/questions/21255438/permission-denied-publickey-fatal-could-not-read-from-remote-repository-whil#33072867

